### PR TITLE
feat: `routeToRegExp` util

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ import {
   findRoute,
   removeRoute,
   findAllRoutes,
+  routeToRegExp,
 } from "rou3";
 ```
 
@@ -45,6 +46,7 @@ import {
   findRoute,
   removeRoute,
   findAllRoutes,
+  routeToRegExp,
 } from "https://esm.sh/rou3";
 ```
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,5 +13,6 @@ export default unjs({
     "unicorn/no-array-callback-reference": 0,
     "unicorn/no-array-method-this-argument": 0,
     "unicorn/prefer-at": 0,
+    "unicorn/prefer-string-raw": 0,
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export { addRoute } from "./operations/add.ts";
 export { findRoute } from "./operations/find.ts";
 export { removeRoute } from "./operations/remove.ts";
 export { findAllRoutes } from "./operations/find-all.ts";
+export { routeToRegExp } from "./regexp.ts";

--- a/src/operations/add.ts
+++ b/src/operations/add.ts
@@ -91,6 +91,8 @@ function _getParamMatcher(segment: string): string | RegExp {
     // Single param
     return segment.slice(1);
   }
-  const regex = segment.replace(/:(\w+)/g, (_, id) => `(?<${id}>\\w+)`);
+  const regex = segment
+    .replace(/:(\w+)/g, (_, id) => `(?<${id}>[^/]+)`)
+    .replace(/\./g, "\\.");
   return new RegExp(`^${regex}$`);
 }

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -1,0 +1,20 @@
+export function routeToRegExp(route: string = "/"): RegExp {
+  const reSegments = [];
+  for (const segment of route.split("/")) {
+    if (!segment) continue;
+    if (segment === "*") {
+      reSegments.push("[^/]*");
+    } else if (segment === "**") {
+      reSegments.push(".*");
+    } else if (segment.includes(":")) {
+      reSegments.push(
+        segment
+          .replace(/:(\w+)/g, (_, id) => `(?<${id}>[^/]+)`)
+          .replace(/\./g, "\\."),
+      );
+    } else {
+      reSegments.push(segment);
+    }
+  }
+  return new RegExp(`^/${reSegments.join("/")}/?$`);
+}

--- a/test/regexp.test.ts
+++ b/test/regexp.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { routeToRegExp } from "../src/index.ts";
+
+describe("routeToRegExp", () => {
+  const cases = {
+    "/path": { regex: /^\/path\/?$/, match: ["/path"] },
+    "/path/:param": {
+      regex: /^\/path\/(?<param>[^/]+)\/?$/,
+      match: ["/path/value"],
+    },
+    "/path/get-:file:ext.txt": {
+      regex: /^\/path\/get-(?<file>[^/]+)(?<ext>[^/]+)\.txt\/?$/,
+      match: ["/path/get-file.ext.txt"],
+    },
+    "/path/:param1/:param2": {
+      regex: /^\/path\/(?<param1>[^/]+)\/(?<param2>[^/]+)\/?$/,
+      match: ["/path/value1/value2"],
+    },
+    "/path/*/foo": {
+      regex: /^\/path\/[^/]*\/foo\/?$/,
+      match: ["/path/anything/foo"],
+    },
+    "/path/**": { regex: /^\/path\/.*\/?$/, match: ["/path/anything/more"] },
+  };
+  for (const [route, expected] of Object.entries(cases)) {
+    it(`should convert route "${route}" to regex "${expected.regex.source}"`, () => {
+      const regex = routeToRegExp(route);
+      expect(regex.source).toBe(expected.regex.source);
+      for (const match of expected.match) {
+        expect(regex.test(match), `Matches ${match}`).toBe(true);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Sometimes it is useful to generate regexp matchers from the same rou3 pattern/convention for single-shot tests.
