### PR TITLE
fix: preserve empty segments

### DIFF
--- a/src/operations/_utils.ts
+++ b/src/operations/_utils.ts
@@ -2,7 +2,8 @@ import { NullProtoObj } from "../_utils.ts";
 import type { MatchedRoute, ParamsIndexMap } from "../types.ts";
 
 export function splitPath(path: string): string[] {
-  return path.split("/").filter(Boolean);
+  const [_, ...s] = path.split("/");
+  return s[s.length - 1] === "" ? s.slice(0, -1) : s;
 }
 
 export function getMatchParams(

--- a/test/_utils.ts
+++ b/test/_utils.ts
@@ -25,7 +25,7 @@ export function formatTree(
 ): string | string[] {
   result.push(
     // prettier-ignore
-    `${prefix}${depth === 0 ? "" : "├── "}${node.key ? `/${node.key}` : (depth === 0 ? "<root>" : "<?>")}${_formatMethods(node)}`,
+    `${prefix}${depth === 0 ? "" : "├── "}${node.key ? `/${node.key}` : (depth === 0 ? "<root>" : "<empty>")}${_formatMethods(node)}`,
   );
 
   const childrenArray = [

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -14,7 +14,7 @@ describe("benchmark", () => {
     `;
     const { bytes, gzipSize } = await getBundleSize(code);
     console.log("bundle size", { bytes, gzipSize });
-    expect(bytes).toBeLessThanOrEqual(2700); // <2.7kb
+    expect(bytes).toBeLessThanOrEqual(2800); // <2.8kb
     expect(gzipSize).toBeLessThanOrEqual(1100); // <1.1kb
   });
 });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -386,6 +386,29 @@ describe("Router lookup", function () {
       },
     );
   });
+
+  describe("empty segments", function () {
+    testRouter(
+      ["/test//route", "/test/:param/route"],
+      (router) =>
+        expect(formatTree(router.root)).toMatchInlineSnapshot(`
+          "<root>
+              ├── /test
+              │       ├── <empty>
+              │       │       ├── /route ┈> [GET] /test//route
+              │       ├── /*
+              │       │       ├── /route ┈> [GET] /test/:param/route"
+        `),
+      {
+        "/test//route": {
+          data: { path: "/test//route" },
+        },
+        "/test/id/route": {
+          data: { path: "/test/:param/route" },
+        },
+      },
+    );
+  });
 });
 
 describe("Router insert", () => {


### PR DESCRIPTION
Thanks @aquapi for pointing out.

Empty segments should be valid in path like `test//foo`