### PR TITLE
fix(types): allow undefined for trailing wildcard params

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface Node<T = unknown> {
 
 export type MatchedRoute<T = unknown> = {
   data: T;
-  params?: Record<string, string>;
+  params?: Record<string, string | undefined>;
 };
 
 type ExtractWildcards<
@@ -42,6 +42,10 @@ type ExtractWildcards<
       ? ExtractWildcards<Rest, Count>
       : never; // No more wildcards found
 
+type ExtractTrailingWildcard<TPath extends string> = TPath extends `${infer Prefix}/*${"" | "/"}`
+  ? Exclude<ExtractWildcards<TPath>, ExtractWildcards<Prefix>>
+  : never;
+
 type ExtractNamedParams<TPath extends string> = TPath extends `${infer _Start}:${infer Rest}` // Found named parameter (:name)
   ? Rest extends `${infer Param}/${infer Tail}` // Parameter followed by path
     ? Param | ExtractNamedParams<`/${Tail}`>
@@ -53,5 +57,9 @@ type ExtractNamedParams<TPath extends string> = TPath extends `${infer _Start}:$
     : never; // No parameters found
 
 export type InferRouteParams<TPath extends string> = {
-  [K in ExtractNamedParams<TPath> | ExtractWildcards<TPath>]: string;
+  [Key in
+    | ExtractNamedParams<TPath>
+    | ExtractWildcards<TPath>]: Key extends ExtractTrailingWildcard<TPath>
+    ? string | undefined
+    : string;
 };

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -592,6 +592,7 @@ describe("wildcard tail extraction (compiled parity)", () => {
   addRoute(router, "GET", "/files/**:path", { path: "FILES" });
   addRoute(router, "GET", "/opt/**", { path: "OPT" });
   addRoute(router, "GET", "/pre/:x/**:rest", { path: "PRE" });
+  addRoute(router, "GET", "/segment/*/", { path: "SEGMENT" });
   const compiledLookup = compileRouter(router);
 
   const lookups = [
@@ -629,6 +630,10 @@ describe("wildcard tail extraction (compiled parity)", () => {
       expect(match("GET", "/pre/v/a/b")).toMatchObject({
         data: { path: "PRE" },
         params: { x: "v", rest: "a/b" },
+      });
+      expect(match("GET", "/segment")).toMatchObject({
+        data: { path: "SEGMENT" },
+        params: { "0": undefined },
       });
     });
   }

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -18,14 +18,20 @@ describe("types", () => {
 
     it("should infer wildcard params", () => {
       type Params = InferRouteParams<"/test/*">;
-      type Expected = { "0": string };
+      type Expected = { "0": string | undefined };
       expectTypeOf<Params>().toEqualTypeOf<Expected>();
+      expectTypeOf<InferRouteParams<"/test/*/">>().toEqualTypeOf<Expected>();
     });
 
     it("should infer multiple wildcard params", () => {
       type Params = InferRouteParams<"/test/*/foo/*/bar">;
       type Expected = { "0": string; "1": string };
       expectTypeOf<Params>().toEqualTypeOf<Expected>();
+      expectTypeOf<InferRouteParams<"/file-*-*">>().toEqualTypeOf<Expected>();
+      expectTypeOf<InferRouteParams<"/test/*/foo/*">>().toEqualTypeOf<{
+        "0": string;
+        "1": string | undefined;
+      }>();
     });
 
     it("should handle catch-all wildcard", () => {

--- a/test/wpt.test.ts
+++ b/test/wpt.test.ts
@@ -260,7 +260,10 @@ const ROUTER_KNOWN_DIFFS = new Set([
 
 type MatchStrategy = {
   name: string;
-  match: (pattern: string, input: string) => { matched: boolean; params: Record<string, string> };
+  match: (
+    pattern: string,
+    input: string,
+  ) => { matched: boolean; params: Record<string, string | undefined> };
   shouldSkip?: (pattern: string) => boolean;
 };
 


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

- Closes https://github.com/h3js/rou3/issues/197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected route parameter typing for trailing and named wildcard segments.
  * Trailing wildcards now accept an omitted value when a route matches zero additional segments.
  * Optional parameters are now typed as possibly undefined.
  * Regex constraints and parameter modifiers are excluded from inferred parameter names.
  * Required route parameters continue to be typed as strings.

* **Tests**
  * Added coverage for trailing wildcard routes, empty matches, multiple wildcard patterns, optional parameters, and constrained parameter names.
  * Confirmed matched route parameter types remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->