### PR TITLE
fix(remove): splice one same-node sibling instead of the whole method bucket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,8 @@ Two different rules, and they must not be conflated:
 - Unescaped `*` inside a segment is treated as an unnamed capture (`"0"`, `"1"`, ...), including mid-pattern forms like `/*.png` and `/file-*-*.png`.
 - Wildcard capture indexing is shared with unnamed regex groups in the same route.
 - `removeRoute()` now treats wildcard-segment patterns as dynamic segments (same classification as add/find/regexp).
+- `removeRoute()` splices one `MethodData` entry by the `route` identity stored at `addRoute` time. Same-node siblings (`/a/:id` vs `/a/:userId`, `/a/**` vs `/a/**:rest`) share `methods[method]`; deleting the whole bucket used to drop them all. When a node's methods become empty, the matching `ctx.static` entry is dropped too.
+
 
 ## Build & Scripts
 

--- a/src/operations/add.ts
+++ b/src/operations/add.ts
@@ -42,6 +42,9 @@ export function addRoute<T>(
 
   let node = ctx.root;
 
+  // Identity for removeRoute: canonical segments, before static keys are rewritten.
+  const route = "/" + segments.join("/");
+
   let _unnamedParamIndex = 0;
 
   const paramsMap: ParamsIndexMap = [];
@@ -103,6 +106,7 @@ export function addRoute<T>(
     data: data || (null as T),
     paramsRegexp,
     paramsMap: hasParams ? paramsMap : undefined,
+    route,
   });
 
   // Static

--- a/src/operations/remove.ts
+++ b/src/operations/remove.ts
@@ -32,20 +32,30 @@ export function removeRoute<T>(ctx: RouterContext<T>, method: string = "", path:
     return;
   }
 
-  _remove(ctx.root, method, segments, 0);
+  _remove(ctx, ctx.root, method, segments, 0, "/" + segments.join("/"));
 }
 
 function _remove(
+  ctx: RouterContext,
   node: Node,
   method: string,
   segments: string[],
   index: number,
+  route: string,
 ): void /* should delete */ {
   if (index === segments.length) {
-    if (node.methods && method in node.methods) {
-      delete node.methods[method];
-      if (Object.keys(node.methods).length === 0) {
-        node.methods = undefined;
+    const entries = node.methods?.[method];
+    if (entries) {
+      const idx = entries.findIndex((e) => e.route === route);
+      if (idx !== -1) {
+        entries.splice(idx, 1);
+      }
+      if (entries.length === 0) {
+        delete node.methods![method];
+        if (Object.keys(node.methods!).length === 0) {
+          node.methods = undefined;
+          _forgetStatic(ctx, node);
+        }
       }
     }
     return;
@@ -57,7 +67,7 @@ function _remove(
   // Wildcard (terminal: `addRoute` stops at `**`, so skip any trailing segments)
   if (key === 2) {
     if (node.wildcard) {
-      _remove(node.wildcard, method, segments, segments.length);
+      _remove(ctx, node.wildcard, method, segments, segments.length, route);
       if (_isEmptyNode(node.wildcard)) {
         node.wildcard = undefined;
       }
@@ -68,7 +78,7 @@ function _remove(
   // Param
   if (key === 1) {
     if (node.param) {
-      _remove(node.param, method, segments, index + 1);
+      _remove(ctx, node.param, method, segments, index + 1, route);
       if (_isEmptyNode(node.param)) {
         node.param = undefined;
       }
@@ -79,7 +89,7 @@ function _remove(
   // Static
   const childNode = node.static?.[key];
   if (childNode) {
-    _remove(childNode, method, segments, index + 1);
+    _remove(ctx, childNode, method, segments, index + 1, route);
     if (_isEmptyNode(childNode)) {
       delete node.static![key];
       if (Object.keys(node.static!).length === 0) {
@@ -96,4 +106,13 @@ function _isEmptyNode(node: Node) {
     node.param === undefined &&
     node.wildcard === undefined
   );
+}
+
+function _forgetStatic(ctx: RouterContext, node: Node): void {
+  const staticMap = ctx.static;
+  for (const key in staticMap) {
+    if (staticMap[key] === node) {
+      delete staticMap[key];
+    }
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export type MethodData<T = unknown> = {
   data: T;
   paramsMap?: ParamsIndexMap;
   paramsRegexp: RegExp[];
+  /** Source pattern after addRoute normalization; used to splice one same-node sibling. */
+  route: string;
 };
 
 export interface Node<T = unknown> {

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -56,7 +56,9 @@ describe("benchmark", () => {
     // ctx.static key and the compiled static dispatch each matching a different
     // set of paths. Lookup paths still use splitPath (one popped empty segment,
     // i.e. `/a//` reaches `/a` but `/a///` does not) — unchanged.
-    expect(bytes).toBeLessThanOrEqual(6640); // <6.64kb
+    // +~20B raw / gzip unchanged: addRoute stores a `route` identity on each
+    // MethodData so removeRoute can splice one same-node sibling (#201).
+    expect(bytes).toBeLessThanOrEqual(6670); // <6.67kb
     expect(gzipSize).toBeLessThanOrEqual(2690); // <2.69kb
   });
 });

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -150,7 +150,7 @@ describe("route matching", () => {
 
   it("remove works", () => {
     removeRoute(router, "GET", "/test");
-    removeRoute(router, "GET", "/test/*");
+    removeRoute(router, "GET", "/test/:id");
     removeRoute(router, "GET", "/test/foo/*");
     removeRoute(router, "GET", "/test/foo/**");
     removeRoute(router, "GET", "/**");

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -792,9 +792,8 @@ describe("Router remove", function () {
       },
     });
 
-    // TODO
-    // removeRoute(router, "GET", "/placeholder/:choo");
-    // expect(findRoute(router,"/placeholder/route")).to.deep.equal(undefined);
+    removeRoute(router, "GET", "/placeholder/:choo");
+    expect(findRoute(router, "GET", "/placeholder/route")).to.deep.equal(undefined);
 
     expect(findRoute(router, "GET", "/placeholder/route/route2")).to.deep.equal({
       data: { path: "/placeholder/:choo/:choo2" },
@@ -964,6 +963,60 @@ describe("Router remove", function () {
         formatTree(createRouter([keep]).root),
       );
     }
+  });
+
+  it("removing one same-node sibling leaves the others", function () {
+    // Same-node siblings share methods[method] (param names / wildcard names /
+    // regex constraints). Removal used to `delete` the whole bucket.
+    for (const [remove, keep, keepPath] of [
+      ["/a/:id", "/a/:userId", "/a/x"],
+      ["/a/**", "/a/**:rest", "/a/x"],
+      ["/a/:id", "/a/:n(\\d+)", "/a/1"],
+      ["/a/*", "/a/:id", "/a/x"],
+    ] as const) {
+      const router = createRouter([remove, keep]);
+      removeRoute(router, "GET", remove);
+      expect(findRoute(router, "GET", keepPath), `remove ${remove} / keep ${keep}`).toMatchObject({
+        data: { path: keep },
+      });
+      expect(
+        compileRouter(router)("GET", keepPath),
+        `compiled remove ${remove} / keep ${keep}`,
+      ).toMatchObject({
+        data: { path: keep },
+      });
+      expect(formatTree(router.root), `remove ${remove} / keep ${keep}`).toBe(
+        formatTree(createRouter([keep]).root),
+      );
+    }
+  });
+
+  it("drops ctx.static when a static route has no methods left", function () {
+    const router = createRouter(["/a/b", "/a/c"]);
+    expect(router.static["/a/b"]).toBeDefined();
+    expect(router.static["/a/c"]).toBeDefined();
+
+    removeRoute(router, "GET", "/a/b");
+
+    expect(router.static["/a/b"]).toBeUndefined();
+    expect(router.static["/a/c"]).toBeDefined();
+    expect(findRoute(router, "GET", "/a/c")).toMatchObject({ data: { path: "/a/c" } });
+  });
+
+  it("keeps ctx.static while another method remains on the same path", function () {
+    const router = createRouter<{ path: string }>({});
+    addRoute(router, "GET", "/a/b", { path: "get" });
+    addRoute(router, "POST", "/a/b", { path: "post" });
+
+    removeRoute(router, "GET", "/a/b");
+
+    expect(router.static["/a/b"]).toBeDefined();
+    expect(findRoute(router, "POST", "/a/b")).toMatchObject({ data: { path: "post" } });
+
+    removeRoute(router, "POST", "/a/b");
+
+    expect(router.static["/a/b"]).toBeUndefined();
+    expect(findRoute(router, "POST", "/a/b")).toBeUndefined();
   });
 
   it("add -> remove restores the original tree", function () {


### PR DESCRIPTION
## Summary

`removeRoute` deleted `node.methods[method]`, so any same-node sibling sharing that bucket was removed too. Examples from #201: `/a/:id` + `/a/:userId`, `/a/**` + `/a/**:rest`, `/a/:id` + `/a/:n(\d+)`, `/a/*` + `/a/:id`.

`addRoute` now stores the normalized pattern on each `MethodData` entry. `_remove` splices only that entry and deletes the method key when the bucket is empty. When a node has no methods left, the matching `ctx.static` entry is dropped so a long-lived router that adds and removes static routes does not retain dead nodes.

Also uncomments the `/placeholder/:choo` removal assertion (different-depth nodes; it already passed) and points the `find.test.ts` "remove works" case at the registered `/test/:id` route instead of `/test/*`, which was only clearing `:id` because of the bucket delete.

Fixes #201.

## Test plan

- [x] `vitest run test/router.test.ts test/find.test.ts test/bench/bundle.test.ts`
- [x] `oxlint .` and `oxfmt --check src test`
- [ ] CI on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Route removal now preserves sibling routes that share the same path segment.
  * Removing the final method from a static route correctly cleans up its entry.
  * Route removal works consistently across parameterized, wildcard, regex, compiled, and tree-based routes.
  * Duplicate and expanded route registrations are removed consistently without affecting separately registered patterns.

* **Documentation**
  * Added documentation for route removal behavior and registration-specific matching.

* **Tests**
  * Added coverage for sibling-route preservation and static-route cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->