### PR TITLE
fix(regexp): stop emitting segments after a terminal catch-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ rou3 supports [URLPattern](https://developer.mozilla.org/en-US/docs/Web/API/URL_
 
 - **Named params** (`:name`) match a single segment.
 - **Single-segment wildcards** (`*`) capture unnamed params (`0`, `1`, ...) and can be used as full or mid-segment tokens (for example `/*` or `/*.png`).
-- **Wildcards** (`**`) match zero or more segments. Use `**:name` to capture.
+- **Wildcards** (`**`) match zero or more segments. Use `**:name` to capture. A wildcard is **terminal**: anything written after it is ignored.
 - **Regex constraints** (`:name(regex)`) restrict matching. Constrained and unconstrained params can coexist on the same node (constrained checked first).
 - **Unnamed groups** (`(regex)`) capture into auto-indexed keys `0`, `1`, etc.
 - **Modifiers:** `:name?` (optional), `:name+` (one or more), `:name*` (zero or more). Can combine with regex: `:id(\d+)?`.
@@ -154,7 +154,7 @@ rou3 aims for URLPattern-compatible syntax but has intentional differences due t
 | Feature                       | URLPattern                         | rou3                                                          |
 | ----------------------------- | ---------------------------------- | ------------------------------------------------------------- |
 | `*` (single star)             | Greedy catch-all `(.*)` across `/` | Single-segment unnamed param `([^/]*)`                        |
-| `**` (double star)            | Literal `**`                       | Catch-all wildcard (zero or more segments)                    |
+| `**` (double star)            | Literal `**`                       | Catch-all wildcard (zero or more segments), always terminal   |
 | `(.*)` in segment             | Greedy match across `/`            | Segment-scoped (does not cross `/`)                           |
 | `{...}+` / `{...}*` groups    | Cross-segment group repetition     | Only supported within a single segment (no `/` in group body) |
 | Path normalization (`.`/`..`) | Resolves `.`/`..` in input paths   | Not done by default (opt-in with `{ normalize: true }`)       |

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -147,6 +147,7 @@ function routeToRegExpSegments(route: string): string[] {
       reSegments.push(`(?<${toRegExpUnnamedKey(idCtr++)}>[^/]*)`);
     } else if (segment.startsWith("**")) {
       reSegments.push(segment === "**" ? "?(?<_>.*)" : `?(?<${toGroupName(segment.slice(3))}>.+)`);
+      break;
     } else if (
       segment.includes(":") ||
       /(^|[^\\])\(/.test(segment) ||

--- a/test/_regexp-cases.ts
+++ b/test/_regexp-cases.ts
@@ -59,7 +59,18 @@ export const regexpCases: Record<string, RegExpCase> = {
       ["/path/anything/more", { _: "anything/more" }],
     ],
   },
+  "/path/**/suffix": {
+    regex: /^\/path\/?(?<_>.*)\/?$/,
+    match: [
+      ["/path/anything/more", { _: "anything/more" }],
+      ["/path/suffix", { _: "suffix" }],
+    ],
+  },
   "/base/**:path": {
+    regex: /^\/base\/?(?<path>.+)\/?$/,
+    match: [["/base/anything/more", { path: "anything/more" }]],
+  },
+  "/base/**:path/suffix": {
     regex: /^\/base\/?(?<path>.+)\/?$/,
     match: [["/base/anything/more", { path: "anything/more" }]],
   },


### PR DESCRIPTION
`routeToRegExp` required a literal suffix after `**` that addRoute drops, so it rejected paths the router matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wildcard (`**`) route patterns now stop processing at the wildcard, ignoring any trailing segments.
  * Improved handling of catch-all wildcards with literal suffixes and named captures.

* **Documentation**
  * Clarified that `**` wildcards are terminal and function as catch-all patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->