### PR TITLE
fix: throw descriptive error on unterminated group in route pattern

### DIFF
--- a/src/operations/add.ts
+++ b/src/operations/add.ts
@@ -143,5 +143,12 @@ function getParamRegexp(segment: string, unnamedStart = 0): [RegExp, number] {
     .replace(/\((?![?<])/g, () => `(?<${toUnnamedGroupKey(_i++)}>`)
     .replace(/\uFFFE(.)/g, (_, c) => (/[.*+?^${}()|[\]\\]/.test(c) ? `\\${c}` : c));
 
-  return [new RegExp(`^${regex}$`), _i];
+  try {
+    return [new RegExp(`^${regex}$`), _i];
+  } catch (error) {
+    throw new Error(
+      `Invalid route pattern "${segment}": unterminated group or invalid regular expression: ${(error as Error).message}`,
+      { cause: error },
+    );
+  }
 }

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -50,7 +50,14 @@ export function routeToRegExp(route: string = "/"): RegExp {
     // that can't be inlined. This is valid in modern JS engines (Node 22+,
     // Chrome 125+, Firefox 129+, Safari 17+) per TC39 proposal, but is not
     // portable to PCRE2 without PCRE2_DUPNAMES.
-    return new RegExp(`^(?:${sources.join("|")})$`);
+    try {
+      return new RegExp(`^(?:${sources.join("|")})$`);
+    } catch (error) {
+      throw new Error(
+        `Invalid route pattern "${route}": unterminated group or invalid regular expression: ${(error as Error).message}`,
+        { cause: error },
+      );
+    }
   }
 
   return _routeToRegExp(route);
@@ -127,7 +134,15 @@ function inlineOptionalGroup(route: string): RegExp | undefined {
 }
 
 function _routeToRegExp(route: string): RegExp {
-  return new RegExp(`^/${routeToRegExpSegments(route).join("/")}/?$`);
+  const segments = routeToRegExpSegments(route);
+  try {
+    return new RegExp(`^/${segments.join("/")}/?$`);
+  } catch (error) {
+    throw new Error(
+      `Invalid route pattern "${route}": unterminated group or invalid regular expression: ${(error as Error).message}`,
+      { cause: error },
+    );
+  }
 }
 
 function routeToRegExpSegments(route: string): string[] {

--- a/test/bench/bundle.test.ts
+++ b/test/bench/bundle.test.ts
@@ -56,8 +56,11 @@ describe("benchmark", () => {
     // ctx.static key and the compiled static dispatch each matching a different
     // set of paths. Lookup paths still use splitPath (one popped empty segment,
     // i.e. `/a//` reaches `/a` but `/a///` does not) — unchanged.
-    expect(bytes).toBeLessThanOrEqual(6640); // <6.64kb
-    expect(gzipSize).toBeLessThanOrEqual(2690); // <2.69kb
+    // +~130B raw / +~70B gzip: getParamRegexp and routeToRegExp catch
+    // unterminated group / syntax errors and throw descriptive Invalid route
+    // pattern errors (#199).
+    expect(bytes).toBeLessThanOrEqual(6800); // <6.80kb
+    expect(gzipSize).toBeLessThanOrEqual(2800); // <2.80kb
   });
 });
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { RouterContext } from "../src/types.ts";
 import { createRouter, formatTree } from "./_utils.ts";
-import { addRoute, findRoute, removeRoute } from "../src/index.ts";
+import { addRoute, findRoute, removeRoute, routeToRegExp } from "../src/index.ts";
 import { compileRouter } from "../src/compiler.ts";
 
 type TestRoute = {
@@ -993,5 +993,15 @@ describe("Router remove", function () {
       removeRoute(router, "GET", route);
       expect(formatTree(router.root), route).toBe(expected);
     }
+  });
+
+  it("throws a descriptive error when a route pattern has an unterminated parenthesis group", () => {
+    const router = createRouter([]);
+    expect(() => addRoute(router, "GET", "/files/(2024", { path: "/files/(2024" })).toThrowError(
+      /Invalid route pattern.*unterminated.*group/,
+    );
+    expect(() => routeToRegExp("/files/(2024")).toThrowError(
+      /Invalid route pattern.*unterminated.*group/,
+    );
   });
 });


### PR DESCRIPTION
## Problem

When a route pattern contains an unbalanced or unterminated `(` group (e.g. `/files/(2024` or `/a(b`), constructing the regular expression inside `getParamRegexp` or `routeToRegExp` causes the JavaScript engine to throw a raw `SyntaxError: Invalid regular expression: ... Unterminated group`. This leaks internal capture group names (such as `__rou3_unnamed_0`) and fails to report which route pattern was invalid.

## Root Cause

`new RegExp(...)` in `getParamRegexp`, `_routeToRegExp`, and `routeToRegExp` was called without error handling for malformed input regexes, surfacing internal regex compilation errors directly to the caller.

## Fix

- Wrap `new RegExp(...)` calls in `src/operations/add.ts` and `src/regexp.ts` in `try...catch` blocks to catch regex compilation failures and rethrow a descriptive `Error: Invalid route pattern "<pattern>": unterminated group or invalid regular expression`.
- Update bundle size threshold in `test/bench/bundle.test.ts` to account for the additional error handling.

## Testing

- Added test case in `test/router.test.ts` asserting descriptive error messages when registering or compiling routes with unbalanced parenthesis groups.
- Verified with `pnpm test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for invalid route patterns, including the problematic pattern and underlying regular-expression details.
  * Invalid patterns now consistently report a clear “Invalid route pattern” error when adding routes or converting routes to regular expressions.

* **Tests**
  * Added coverage for malformed patterns with unterminated groups.
  * Updated bundle-size checks to reflect the enhanced validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->