### PR TITLE
fix(regexp): enforce segment boundary for wildcard catch-alls

### DIFF
--- a/src/regexp-to-route.ts
+++ b/src/regexp-to-route.ts
@@ -202,6 +202,12 @@ function paramToken(name: string, body: string): string {
 
 /** Classify a param inside an optional group (`:name?`, `:name*`, ...). */
 function optionalParam(name: string, body: string): string {
+  if (name === "_" && body === ".*") {
+    return "**";
+  }
+  if (body === ".+") {
+    return `**:${name}`;
+  }
   if (body === "[^/]+") {
     return `:${name}?`;
   }

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -146,7 +146,16 @@ function routeToRegExpSegments(route: string): string[] {
     if (segment === "*") {
       reSegments.push(`(?<${toRegExpUnnamedKey(idCtr++)}>[^/]*)`);
     } else if (segment.startsWith("**")) {
-      reSegments.push(segment === "**" ? "?(?<_>.*)" : `?(?<${toGroupName(segment.slice(3))}>.+)`);
+      const isWildcard = segment === "**";
+      const name = isWildcard ? "_" : toGroupName(segment.slice(3));
+      const pattern = isWildcard ? ".*" : ".+";
+      if (reSegments.length > 0) {
+        const prev = reSegments.pop()!;
+        reSegments.push(`${prev}(?:/(?<${name}>${pattern}))?`);
+      } else {
+        reSegments.push(isWildcard ? `?(?<${name}>${pattern})` : `?(?<${name}>${pattern})`);
+      }
+      break;
     } else if (
       segment.includes(":") ||
       /(^|[^\\])\(/.test(segment) ||

--- a/test/_regexp-cases.ts
+++ b/test/_regexp-cases.ts
@@ -52,15 +52,11 @@ export const regexpCases: Record<string, RegExpCase> = {
     match: [["/path/file-a-b.png", { "0": "a", "1": "b" }]],
   },
   "/path/**": {
-    regex: /^\/path\/?(?<_>.*)\/?$/,
-    match: [
-      ["/path/", { _: "" }],
-      ["/path", { _: "" }],
-      ["/path/anything/more", { _: "anything/more" }],
-    ],
+    regex: /^\/path(?:\/(?<_>.*))?\/?$/,
+    match: [["/path/", { _: "" }], ["/path"], ["/path/anything/more", { _: "anything/more" }]],
   },
   "/base/**:path": {
-    regex: /^\/base\/?(?<path>.+)\/?$/,
+    regex: /^\/base(?:\/(?<path>.+))?\/?$/,
     match: [["/base/anything/more", { path: "anything/more" }]],
   },
   "/static%3Apath/\\*/\\*\\*": {
@@ -163,7 +159,7 @@ export const regexpCases: Record<string, RegExpCase> = {
     match: [["/api/abc", { "test-id": "abc" }], ["/api"]],
   },
   "/api/**:test-id": {
-    regex: /^\/api\/?(?<__rou3_esc_test_hid>.+)\/?$/,
+    regex: /^\/api(?:\/(?<__rou3_esc_test_hid>.+))?\/?$/,
     match: [["/api/a/b", { "test-id": "a/b" }]],
   },
   "/files/:file-name.json": {

--- a/test/regexp-to-route.test.ts
+++ b/test/regexp-to-route.test.ts
@@ -26,8 +26,8 @@ describe("regExpToRoute", () => {
     expect(regExpToRoute(/^\/path\/(?<param>[^/]+)\/?$/)).toBe("/path/:param");
     expect(regExpToRoute(/^\/path\/(?<_0>[^/]*)\/foo\/?$/)).toBe("/path/*/foo");
     expect(regExpToRoute(/^\/path\/(?<_0>[^/]*)\.png\/?$/)).toBe("/path/*.png");
-    expect(regExpToRoute(/^\/path\/?(?<_>.*)\/?$/)).toBe("/path/**");
-    expect(regExpToRoute(/^\/base\/?(?<path>.+)\/?$/)).toBe("/base/**:path");
+    expect(regExpToRoute(/^\/path(?:\/(?<_>.*))?\/?$/)).toBe("/path/**");
+    expect(regExpToRoute(/^\/base(?:\/(?<path>.+))?\/?$/)).toBe("/base/**:path");
     expect(regExpToRoute(/^\/path\/(?<id>\d+)\/?$/)).toBe("/path/:id(\\d+)");
     expect(regExpToRoute(/^\/path(?:\/(?<id>[^/]+))?\/?$/)).toBe("/path/:id?");
     expect(regExpToRoute(/^\/path(?:\/(?<rest>.*))?\/?$/)).toBe("/path/:rest*");
@@ -39,7 +39,7 @@ describe("regExpToRoute", () => {
     // emitted escaped; reversing must restore the original name, not leak the
     // internal form as `:__rou3_esc_test_hid`.
     expect(regExpToRoute(/^\/api\/(?<__rou3_esc_test_hid>[^/]+)\/?$/)).toBe("/api/:test-id");
-    expect(regExpToRoute(/^\/api\/?(?<__rou3_esc_test_hid>.+)\/?$/)).toBe("/api/**:test-id");
+    expect(regExpToRoute(/^\/api(?:\/(?<__rou3_esc_test_hid>.+))?\/?$/)).toBe("/api/**:test-id");
     expect(regExpToRoute(/^\/api(?:\/(?<__rou3_esc_test_hid>[^/]+))?\/?$/)).toBe("/api/:test-id?");
     expect(regExpToRoute(/^\/api\/(?<__rou3_esc_0>[^/]+)\/?$/)).toBe("/api/:0");
     expect(regExpToRoute(/^\/mix\/(?<__rou3_esc_a_hb>[^/]+)\.(?<a_b>[^/]+)\/?$/)).toBe(

--- a/test/regexp.test.ts
+++ b/test/regexp.test.ts
@@ -46,6 +46,15 @@ describe("routeToRegExp", () => {
     });
   }
 
+  it("does not over-match sibling paths for wildcard routes", () => {
+    const re = routeToRegExp("/pub/**");
+    expect(re.test("/pub")).toBe(true);
+    expect(re.test("/pub/")).toBe(true);
+    expect(re.test("/pub/a")).toBe(true);
+    expect(re.test("/pubx")).toBe(false);
+    expect(re.test("/publicsecret")).toBe(false);
+  });
+
   // Trailing single optional groups are compiled inline (`(?:...)?`) rather than
   // expanded into an alternation of full routes, so a param before the group is
   // never emitted twice. Duplicate named groups are valid JS but rejected by

--- a/test/wpt.test.ts
+++ b/test/wpt.test.ts
@@ -196,10 +196,6 @@ const KNOWN_DIFFS = new Set([
 // These patterns use syntax that routeToRegExp handles but the radix tree cannot represent
 // Known diffs that only apply to routeToRegExp (router handles these correctly)
 const REGEXP_ONLY_KNOWN_DIFFS = new Set([
-  // `**` as literal — routeToRegExp treats `**` as catch-all;
-  // router also treats `**` as catch-all but doesn't match `/foobar`
-  "/foo/** → /foobar [no match]",
-
   // Non-`/`-prefixed input — router prepends `/` for lookup
   "/foo/bar → foo/bar [match]",
 ]);


### PR DESCRIPTION
## Problem
`routeToRegExp` compiled wildcard routes like `/pub/**` into `/^\/pub\/?(?<_>.*)\/?$/`. Because `\/?` was optional, the `(?<_>.*)` group matched mid-segment without requiring a `/` delimiter, causing the regex to match sibling paths such as `/pubx` and `/publicsecret` that `findRoute` rejects.

## Root Cause
When compiling segments in `routeToRegExpSegments`, `segment.startsWith("**")` pushed `?(?<_>.*)`, which produced `\/?(?<_>.*)` when joined by `/`. A segment separator should be required when `**` follows a preceding path segment.

## Fix
1. In `routeToRegExpSegments`, when a wildcard segment follows an existing segment, append `(?:/(?<name>pattern))?` to the preceding segment.
2. In `src/regexp-to-route.ts`, support reverse-mapping `(?:/(?<_>.*))?` to `**` and `(?:/(?<name>.+))?` to `**:name` for consistent round-tripping.
3. Update regex fixtures and WPT test expectations.

## Testing
1. Added unit test in `test/regexp.test.ts` verifying `/pub/**` does not match `/pubx` or `/publicsecret`.
2. Updated shared regexp cases in `test/_regexp-cases.ts` and `test/regexp-to-route.test.ts`.
3. Ran `pnpm test` (all 13 test suites pass, 859 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `**` wildcard routes to match across multiple path segments.
  - Prevented wildcard routes such as `/pub/**` from incorrectly matching sibling paths like `/publicsecret`.
  - Improved handling of named catch-all parameters and optional trailing segments.
  - Corrected wildcard behavior for paths with and without trailing slashes.

- **Tests**
  - Added coverage for multi-segment wildcard matching and sibling-path exclusions.
  - Updated route conversion expectations for optional wildcard segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->